### PR TITLE
create the Proxy task

### DIFF
--- a/iodrivers_base.orogen
+++ b/iodrivers_base.orogen
@@ -46,3 +46,15 @@ task_context "Task" do
     fd_driven
 end
 
+# Simple task that allows to mirror the I/O from a port supported by
+# iodrivers_base::Driver onto the io_read_listener and io_write_listener ports
+task_context "Proxy" do
+    subclasses "Task"
+
+    # Data that should be sent to io_port
+    input_port("tx", "iodrivers_base/RawPacket").
+        needs_reliable_connection
+    # Data received on io_port
+    output_port "rx", "iodrivers_base/RawPacket"
+end
+

--- a/tasks/Proxy.cpp
+++ b/tasks/Proxy.cpp
@@ -1,0 +1,91 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.cpp */
+
+#include "Proxy.hpp"
+#include <iodrivers_base/Driver.hpp>
+
+using namespace iodrivers_base;
+
+namespace
+{
+    class DummyDriver : public Driver
+    {
+    public:
+        DummyDriver()
+            : Driver(iodrivers_base::Proxy::BUFFER_SIZE) {}
+
+        int extractPacket(boost::uint8_t const* buffer, size_t size) const
+        { return size; }
+    };
+}
+
+Proxy::Proxy(std::string const& name)
+    : ProxyBase(name)
+{
+}
+
+Proxy::Proxy(std::string const& name, RTT::ExecutionEngine* engine)
+    : ProxyBase(name, engine)
+{
+}
+
+Proxy::~Proxy()
+{
+}
+
+/// The following lines are template definitions for the various state machine
+// hooks defined by Orocos::RTT. See Proxy.hpp for more detailed
+// documentation about them.
+
+bool Proxy::configureHook()
+{
+    rx_packet.data.resize(BUFFER_SIZE);
+    setDriver(new DummyDriver);
+    mDriver->openURI(_io_port.get());
+    if (! ProxyBase::configureHook())
+        return false;
+
+    return true;
+}
+bool Proxy::startHook()
+{
+    if (! ProxyBase::startHook())
+        return false;
+    return true;
+}
+void Proxy::updateHook()
+{
+    ProxyBase::updateHook();
+
+    while (_tx.read(tx_packet, false) == RTT::NewData)
+        mDriver->writePacket(tx_packet.data.data(), tx_packet.data.size());
+}
+void Proxy::processIO()
+{
+    try
+    {
+        int packet_size = mDriver->readPacket(buffer, 1024);
+        rx_packet.time = base::Time::now();
+        rx_packet.data.resize(packet_size);
+        memcpy(rx_packet.data.data(), buffer, packet_size);
+        _rx.write(rx_packet);
+    }
+    catch (TimeoutError)
+    {
+    }
+}
+
+void Proxy::errorHook()
+{
+    ProxyBase::errorHook();
+}
+void Proxy::stopHook()
+{
+    ProxyBase::stopHook();
+}
+void Proxy::cleanupHook()
+{
+    ProxyBase::cleanupHook();
+    delete mDriver;
+    mDriver = 0;
+}
+

--- a/tasks/Proxy.hpp
+++ b/tasks/Proxy.hpp
@@ -1,0 +1,115 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.hpp */
+
+#ifndef IODRIVERS_BASE_PROXY_TASK_HPP
+#define IODRIVERS_BASE_PROXY_TASK_HPP
+
+#include "iodrivers_base/ProxyBase.hpp"
+
+namespace iodrivers_base {
+
+    /*! \class Proxy 
+     * \brief The task context provides and requires services. It uses an ExecutionEngine to perform its functions.
+     * Essential interfaces are operations, data flow ports and properties. These interfaces have been defined using the oroGen specification.
+     * In order to modify the interfaces you should (re)use oroGen and rely on the associated workflow.
+     * Simple task that allows to mirror the I/O from a port supported by
+iodrivers_base::Driver onto the io_read_listener and io_write_listener ports
+     * \details
+     * The name of a TaskContext is primarily defined via:
+     \verbatim
+     deployment 'deployment_name'
+         task('custom_task_name','iodrivers_base::Proxy')
+     end
+     \endverbatim
+     *  It can be dynamically adapted when the deployment is called with a prefix argument. 
+     */
+    class Proxy : public ProxyBase
+    {
+	friend class ProxyBase;
+    public:
+        static const int BUFFER_SIZE = 1024;
+
+    protected:
+        boost::uint8_t buffer[BUFFER_SIZE];
+        void processIO();
+        iodrivers_base::RawPacket rx_packet, tx_packet;
+
+    public:
+        /** TaskContext constructor for Proxy
+         * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.
+         * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
+         */
+        Proxy(std::string const& name = "iodrivers_base::Proxy");
+
+        /** TaskContext constructor for Proxy 
+         * \param name Name of the task. This name needs to be unique to make it identifiable for nameservices. 
+         * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task. 
+         * 
+         */
+        Proxy(std::string const& name, RTT::ExecutionEngine* engine);
+
+        /** Default deconstructor of Proxy
+         */
+	~Proxy();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from PreOperational to Stopped. If it returns false, then the
+         * component will stay in PreOperational. Otherwise, it goes into
+         * Stopped.
+         *
+         * It is meaningful only if the #needs_configuration has been specified
+         * in the task context definition with (for example):
+         \verbatim
+         task_context "TaskName" do
+           needs_configuration
+           ...
+         end
+         \endverbatim
+         */
+        bool configureHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to Running. If it returns false, then the component will
+         * stay in Stopped. Otherwise, it goes into Running and updateHook()
+         * will be called.
+         */
+        bool startHook();
+
+        /** This hook is called by Orocos when the component is in the Running
+         * state, at each activity step. Here, the activity gives the "ticks"
+         * when the hook should be called.
+         *
+         * The error(), exception() and fatal() calls, when called in this hook,
+         * allow to get into the associated RunTimeError, Exception and
+         * FatalError states. 
+         *
+         * In the first case, updateHook() is still called, and recover() allows
+         * you to go back into the Running state.  In the second case, the
+         * errorHook() will be called instead of updateHook(). In Exception, the
+         * component is stopped and recover() needs to be called before starting
+         * it again. Finally, FatalError cannot be recovered.
+         */
+        void updateHook();
+
+        /** This hook is called by Orocos when the component is in the
+         * RunTimeError state, at each activity step. See the discussion in
+         * updateHook() about triggering options.
+         *
+         * Call recover() to go back in the Runtime state.
+         */
+        void errorHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Running to Stopped after stop() has been called.
+         */
+        void stopHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to PreOperational, requiring the call to configureHook()
+         * before calling start() again.
+         */
+        void cleanupHook();
+    };
+}
+
+#endif
+


### PR DESCRIPTION
The task allows to map an iodrivers-supported I/O to ports and back.
This is really meant as a way to read / log / mirror the I/O to orocos
and back.