### PR TITLE
generalize Proxy to allow handling any raw-packet-oriented stream driver

### DIFF
--- a/iodrivers_base.orogen
+++ b/iodrivers_base.orogen
@@ -56,5 +56,8 @@ task_context "Proxy" do
         needs_reliable_connection
     # Data received on io_port
     output_port "rx", "iodrivers_base/RawPacket"
+
+    port_driven
+    fd_driven
 end
 

--- a/tasks/Proxy.hpp
+++ b/tasks/Proxy.hpp
@@ -30,6 +30,9 @@ iodrivers_base::Driver onto the io_read_listener and io_write_listener ports
 
     protected:
         virtual int createProxyDriver();
+        virtual void writePacket(RawPacket const& packet);
+        virtual void readPacket(RawPacket& packet);
+
         void processIO();
         int buffer_size;
         std::vector<boost::uint8_t> packet_buffer;

--- a/tasks/Proxy.hpp
+++ b/tasks/Proxy.hpp
@@ -26,11 +26,13 @@ iodrivers_base::Driver onto the io_read_listener and io_write_listener ports
     {
 	friend class ProxyBase;
     public:
-        static const int BUFFER_SIZE = 1024;
+        static const int DUMMY_BUFFER_SIZE = 1024;
 
     protected:
-        boost::uint8_t buffer[BUFFER_SIZE];
+        virtual int createProxyDriver();
         void processIO();
+        int buffer_size;
+        std::vector<boost::uint8_t> packet_buffer;
         iodrivers_base::RawPacket rx_packet, tx_packet;
 
     public:

--- a/test/test_proxy.rb
+++ b/test/test_proxy.rb
@@ -1,0 +1,80 @@
+require 'minitest/spec'
+require 'orocos/test/component'
+require 'minitest/autorun'
+
+describe 'iodrivers_base::Proxy' do
+    include Orocos::Test::Component
+
+    describe "file-descriptor base I/O" do
+        start 'proxy', 'iodrivers_base::Proxy' => 'proxy'
+        writer 'proxy', 'tx', attr_name: 'tx'
+        reader 'proxy', 'rx', attr_name: 'rx'
+    
+        before do
+            # We currently have no simple way to forward a file descriptor to
+            # the component and have it use it. Randomly assign a port locally,
+            # close the socket and ask the component to use it to reduce the
+            # likelihood of port collision
+            @local_socket = UDPSocket.new
+            @local_socket.bind('localhost', 0)
+            local_port = @local_socket.local_address.ip_port
+            component_socket = UDPSocket.new
+            component_socket.bind('localhost', 0)
+            component_port = component_socket.local_address.ip_port
+            component_socket.close
+            @local_socket.connect 'localhost', component_port
+
+            proxy.io_port = "udp://localhost:#{local_port}:#{component_port}"
+            proxy.configure
+            proxy.start
+        end
+
+        it "forwards the data received on io_raw_in to rx" do
+            @local_socket.write "\x1\x2\x3\x4"
+            assert_receives "\x1\x2\x3\x4", rx
+        end
+        it "forwards the data received on tx to io_raw_out" do
+            tx.write make_packet("\x1\x2\x3\x4")
+            assert_equal "\x1\x2\x3\x4", @local_socket.read(4)
+        end
+    end
+
+    describe "using the io_raw_in and io_raw_out instead of the file descriptor" do
+        start 'proxy', 'iodrivers_base::Proxy' => 'proxy'
+        writer 'proxy', 'tx', attr_name: 'tx'
+        reader 'proxy', 'rx', attr_name: 'rx'
+    
+        before do
+            @io_raw_in  = data_writer proxy.io_raw_in
+            @io_raw_out = data_reader proxy.io_raw_out
+            proxy.configure
+            proxy.start
+        end
+
+        it "forwards the data received on io_raw_in to rx" do
+            @io_raw_in.write(make_packet("\x1\x2\x3\x4"))
+            assert_receives "\x1\x2\x3\x4", rx
+        end
+        it "forwards the data received on tx to io_raw_out" do
+            tx.write make_packet("\x1\x2\x3\x4")
+            assert_receives "\x1\x2\x3\x4", @io_raw_out
+        end
+    end
+
+    def assert_receives(expected_data, reader)
+        data = ''
+        while data.size < expected_data.size
+            new_packet = assert_has_one_new_sample reader
+            data.concat(new_packet.data.to_byte_array[8..-1])
+        end
+        assert_equal expected_data, data[0, expected_data.size]
+    end
+
+    def make_packet(data)
+        packet = tx.new_sample
+        packet.time = Time.now
+        packet.data.from_buffer([data.size].pack("Q<") + data)
+        packet
+    end
+end
+


### PR DESCRIPTION
The task can now handle any Driver that interprets a byte stream into
packets, but does not decode the packet contents themselves.